### PR TITLE
Use RwLock instead of RefCell for access token

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 This is a fork of the master branch of davidgraeff/firestore-db-and-auth-rs.
 * Updated serde_value_to_firebase_value to read chrono::DateTime value as timestamp_value
 * Updated updateMask.fieldPaths to be specified per updated fields to fix invalid property value when updating structs of nested map
+* Use RwLock instead of RefCell for access_token and jwt in ServiceSession::Session and UserSession::Session so that it can be passed safely between threads 
 
 # Firestore API and Auth
 

--- a/tests/documents.rs
+++ b/tests/documents.rs
@@ -74,7 +74,13 @@ fn service_account_session() -> errors::Result<()> {
 
     println!("Partial write document");
 
-    a_map.insert("a".to_string(), DemoMapDTO {a_int: 12, a_map: HashMap::default()});
+    a_map.insert(
+        "a".to_string(),
+        DemoMapDTO {
+            a_int: 12,
+            a_map: HashMap::default(),
+        },
+    );
 
     let obj = DemoDTOPartial {
         a_string: None,
@@ -137,9 +143,15 @@ fn user_account_session() -> errors::Result<()> {
     assert_eq!(user_session.user_id, TEST_USER_ID);
 
     let mut a_map = HashMap::<String, DemoMapDTO>::new();
-    let mut b_map= HashMap::new();
+    let mut b_map = HashMap::new();
     b_map.insert("a".to_string(), "123".to_string());
-    a_map.insert("a".to_string(), DemoMapDTO {a_int: 12, a_map: HashMap::default()});
+    a_map.insert(
+        "a".to_string(),
+        DemoMapDTO {
+            a_int: 12,
+            a_map: HashMap::default(),
+        },
+    );
 
     let obj = DemoDTO {
         a_string: "abc".to_owned(),


### PR DESCRIPTION
RefCell cannot be passed between threads safely. RwLock is used